### PR TITLE
added first delete method for deleting specific comments by their ID

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -266,3 +266,31 @@ describe("PATCH /api/articles/:article_id", () => {
       });
   });
 });
+
+describe("DELETE /api/comments/:comment_id", () => {
+  test("204: Should remove a comment from our database by providing the comment_id of the comment we intend to remove.", () => {
+    return request(app)
+      .delete("/api/comments/1")
+      .expect(204)
+      .then((response) => {
+        expect(response.statusCode).toBe(204);
+      });
+  });
+  test("404: Should return an error when attempting to delete a comment with a valid comment_id type, but doesnt exist", () => {
+    return request(app)
+      .delete("/api/comments/99999")
+      .expect(404)
+      .then((response) => {
+        expect(response.statusCode).toBe(404);
+      });
+  });
+  test("400: Should return an error when attempting to delete a comment with a invalid comment_id type", () => {
+    return request(app)
+      .delete("/api/comments/hello")
+      .expect(400)
+      .then((response) => {
+        expect(response.statusCode).toBe(400);
+        expect(response.body.msg).toBe("Bad request");
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const {
 const endpoints = require("./endpoints.json");
 const { postComment } = require("./controllers/postControllers");
 const { patchArticle } = require("./controllers/patchControllers");
+const { deleteComment } = require("./controllers/deleteControllers");
 
 const app = express();
 
@@ -28,6 +29,8 @@ app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id/comments", getComments);
 
 app.post("/api/articles/:article_id/comments", postComment);
+
+app.delete("/api/comments/:comment_id", deleteComment);
 
 app.use((req, res) => {
   res.status(404).send({ msg: "The requested endpoint does not exist." });

--- a/controllers/deleteControllers.js
+++ b/controllers/deleteControllers.js
@@ -1,0 +1,12 @@
+const { removeComment } = require("../models/removeModels");
+
+exports.deleteComment = (req, res, next) => {
+  const { comment_id } = req.params;
+  removeComment(comment_id)
+    .then(() => {
+      res.status(204).send();
+    })
+    .catch((err) => {
+      next(err);
+    });
+};

--- a/controllers/postControllers.js
+++ b/controllers/postControllers.js
@@ -16,7 +16,6 @@ exports.postComment = (req, res, next) => {
       res.status(200).send({ comment: comment });
     })
     .catch((err) => {
-      console.log(err);
       next(err);
     });
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -48,5 +48,16 @@
       "article_id": 5,
       "created_at": 1606176480000
     }
+  },
+  "PATCH /api/articles/:article_id": {
+    "description": "Serves to update a given articles vote count, either increasing or decreasing depending on the body. Must provide a valid username and inc_votes type.",
+    "exampleResponse": {
+      "comment_id": 5,
+      "body": "I am 100% sure that we're not completely sure.",
+      "votes": 1,
+      "author": "butter_bridge",
+      "article_id": 5,
+      "created_at": 1606176480000
+    }
   }
 }

--- a/models/removeModels.js
+++ b/models/removeModels.js
@@ -1,0 +1,16 @@
+const db = require("../db/connection.js");
+
+exports.removeComment = (id) => {
+  return db
+    .query(
+      `DELETE FROM comments
+        WHERE comment_id = $1
+        RETURNING *;`,
+      [id]
+    )
+    .then((data) => {
+      if (data.rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "Entry not found" });
+      }
+    });
+};


### PR DESCRIPTION
Added my apps first DELETE method for individual comments.
Notes of changes:
- App.test.js
Added a test for a 204 response that is expecting no returned value from the method, as a 204 naturally doesnt allow a body request I simply tested for the status code alone. Similar to my other methods, added tests for a 404 and 400 that return either not found or bad request respectively depending on the parametric endpoint.

- App.js
New endpoint added to my list.

- Controllers/models
Added my new files and functions to handle my delete request, unlike other methods we arent sending any response body upon a success, only the 204. Error handling similar to previous methods.

- Endpoints.json
Updated my endpoints.json with the previous patch method.