### PR TITLE
updated my get comments by article id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -220,6 +220,15 @@ describe("GET /api/articles/:article_id/comments", () => {
         });
       });
   });
+  test("200: returns an empty array if a valid article ID is passed but the article has no comments.", () => {
+    return request(app)
+      .get("/api/articles/4/comments")
+      .expect(200)
+      .then(({ body }) => {
+        const articleComments = body.comments;
+        expect(articleComments.length).toBe(0);
+      });
+  });
   test("400: should return 400 error code and message if parametric endpoint is of wrong type or formatted incorrectly.", () => {
     return request(app)
       .get("/api/articles/wrong/comments")
@@ -233,7 +242,7 @@ describe("GET /api/articles/:article_id/comments", () => {
       .get("/api/articles/100/comments")
       .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe("Not found");
+        expect(body.msg).toBe("Entry not found");
       });
   });
 });

--- a/controllers/getControllers.js
+++ b/controllers/getControllers.js
@@ -43,7 +43,10 @@ exports.getArticles = (req, res, next) => {
 
 exports.getComments = (req, res, next) => {
   const { article_id } = req.params;
-  fetchComments(article_id)
+  fetchArticleById(article_id)
+    .then(() => {
+      return fetchComments(article_id);
+    })
     .then((comments) => {
       res.status(200).send({ comments: comments });
     })

--- a/models/fetchModels.js
+++ b/models/fetchModels.js
@@ -81,9 +81,6 @@ exports.fetchComments = (articleID) => {
       [articleID]
     )
     .then((comments) => {
-      if (comments.rows.length === 0) {
-        return Promise.reject({ status: 404, msg: "Not found" });
-      }
       return comments.rows;
     });
 };


### PR DESCRIPTION
Altered my 'GET /api/articles/:article_id/comments' endpoint to now return an empty array when passed an existing articles ID that however contains no comments. Previously would throw an error.
I achieved this by calling my 'GET /api/article/:article_id' endpoint to handle the error handling for if an article exists or not, this allowed me to remove the error handling in my 'GET /api/articles/:article_id/comments' and instead return an empty array if the article had no comments.