### PR TITLE
Get article by ID should now respond with comment_count on its body.

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -59,6 +59,7 @@ describe("GET /api/articles/:article_id", () => {
           title: "Living in the shadow of a great man",
           topic: "mitch",
           author: "butter_bridge",
+          comment_count: "11",
           body: "I find this existence challenging",
           created_at: "2020-07-09T20:11:00.000Z",
           votes: 100,

--- a/models/fetchModels.js
+++ b/models/fetchModels.js
@@ -12,8 +12,15 @@ exports.fetchTopics = () => {
 exports.fetchArticleById = (articleID) => {
   return db
     .query(
-      `SELECT * FROM articles
-        WHERE article_id = $1`,
+      `SELECT articles.article_id, articles.votes, articles.title, 
+      articles.topic, articles.author, articles.body, 
+      articles.created_at, articles.article_img_url,
+      COUNT(comments.comment_id) AS comment_count
+      FROM articles
+      LEFT JOIN comments
+      ON articles.article_id = comments.article_id
+      WHERE articles.article_id = $1 
+      GROUP BY articles.article_id, articles.title, articles.topic, articles.author, articles.created_at, articles.article_img_url, articles.votes;`,
       [articleID]
     )
     .then((article) => {


### PR DESCRIPTION
Changed my fetchArticleByID model method to now query how many comments a particular article has referencing it. This value is not returned on the response body as 'comment_count'. This was achieve by changing my SQL query from a generic search into a search joining 2 tables and running the COUNT function on comments.