### PR TITLE
pagination for my articles completed.

### DIFF
--- a/controllers/getControllers.js
+++ b/controllers/getControllers.js
@@ -38,6 +38,7 @@ exports.getArticles = (req, res, next) => {
       res.status(200).send({ articles: articles });
     })
     .catch((err) => {
+      console.log(err);
       next(err);
     });
 };


### PR DESCRIPTION
## Pagination added to GET articles.
- In this branch i have refactored the majority of my GET articles model function. I made it more dynamic and done all my query in 1 literal without splitting it up.
-  I added a counter that will detect how many values need to be passed in via my values array, and coded them to represent the correct value in the sql query. 
- I have also added the potential to add additional query params in the future (similar to 'topics') with how i am now handling the WHERE section of my query.
- I have implemented pagination by offering a limit and page query parameter that can return a certain slice of the data set.
- Even after pagination, my query now returns total articles matching the search filters without being confined to the results returned by pagination.
- Therefore my return value for this endpoint has changed from an array of articles to an array containing an array of articles and an object with data that should look like ``` {page: '2', limit: '5', articleTotal: '13' }```